### PR TITLE
fixed IEnumerator

### DIFF
--- a/Slowsharp/Runner/Runner.cs
+++ b/Slowsharp/Runner/Runner.cs
@@ -340,6 +340,7 @@ namespace Slowsharp
                     method.ReturnType.CompiledType == typeof(IEnumerator))
                 {
                     var enumerator = new SSEnumerator(this, node.Body, vf);
+                    enumerator.Method = method;
                     Ret = HybInstance.Object(enumerator);
                 }
                 else

--- a/Slowsharp/Runtime/SSEnumerator.cs
+++ b/Slowsharp/Runtime/SSEnumerator.cs
@@ -39,7 +39,9 @@ namespace Slowsharp
             if (pc == -1)
                 return false;
 
+            runner.Ctx.PushMethod(Method);
             pc = runner.RunBlock(block, vf, pc);
+            runner.Ctx.PopMethod();
 
             // -1 means EndOfMethod
             return pc == -1 ? false : true;


### PR DESCRIPTION
example:

IEnumerator m(){ Debug.Log(1); yield return null; Debug.Log(Vector3.up); }}

Will throw exception on Vector3.up, i fixed that