### PR TITLE
accessing static variable from compiled type fix

### DIFF
--- a/Slowsharp/Hyb/Invokable.cs
+++ b/Slowsharp/Hyb/Invokable.cs
@@ -62,7 +62,7 @@ namespace Slowsharp
                     args = ExpandArgs(args, CompiledMethod);
 
                 var unwrappedArgs = args.Unwrap();
-                var ret = CompiledMethod.Invoke(_this?.InnerObject, unwrappedArgs);
+                var ret = CompiledMethod.Invoke(_this == null ? null : _this.IsCompiledType ? _this.InnerObject:_this.Parent.InnerObject, unwrappedArgs);
 
                 if (hasRefOrOut)
                 {


### PR DESCRIPTION
compiled type:
class bs{
public static int a;
}

hyb type will throw exception without this fix
```csharp
class test : bs{
main()
{
Debug.Log(a);
}
}
