### PR TITLE
fix yield

### DIFF
--- a/SlowSharp.Test/SlowSharp.Test.csproj
+++ b/SlowSharp.Test/SlowSharp.Test.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Syntax\ControlFlow\Switch.cs" />
     <Compile Include="Syntax\ControlFlow\While.cs" />
+    <Compile Include="Syntax\ControlFlow\Yield.cs" />
     <Compile Include="Syntax\Enum\Enum.cs" />
     <Compile Include="Syntax\Feature\Lambda.cs" />
     <Compile Include="Syntax\Feature\StringInterpolation.cs" />

--- a/SlowSharp.Test/Syntax/ControlFlow/Yield.cs
+++ b/SlowSharp.Test/Syntax/ControlFlow/Yield.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Slowsharp.Test
+{
+    [TestClass]
+    public class YieldTest
+    {
+        [TestMethod]
+        public void BasicYieldStatement()
+        {
+            Assert.AreEqual(TestRunner.RunRaw(@"
+using System.Collections;
+
+class Program
+{
+    public static int s = 0;
+
+    public static IEnumerator Test() {
+        yield return 1;
+        yield return 2;
+        yield return 3;
+        yield return 4;
+        yield return 5;
+    }
+
+    static void Main() {
+       var c = Test();
+
+       while (c.MoveNext()) {
+         s += c.Current;
+       }
+
+       return s;
+    }
+}
+"), 1 + 2 + 3 + 4 + 5);
+        }
+    }
+}

--- a/Slowsharp/Runner/Runner.Statement.cs
+++ b/Slowsharp/Runner/Runner.Statement.cs
@@ -17,6 +17,8 @@ namespace Slowsharp
 
             var children = node.ChildNodes().ToArray();
 
+            if (children.Length == pc)
+                  return -1;
         
             for (; pc < children.Length; pc++)
             {
@@ -48,9 +50,7 @@ namespace Slowsharp
             }
 
             Vars = prevVars;
-            if (children.Length == pc) 
-                pc++;
-            else if (pc>children.Length)
+            if (children.Length == pc && children.Length != 1)
                 return -1;
 
             return pc;

--- a/Slowsharp/Runner/Runner.Statement.cs
+++ b/Slowsharp/Runner/Runner.Statement.cs
@@ -50,7 +50,7 @@ namespace Slowsharp
             }
 
             Vars = prevVars;
-            if (children.Length == pc && children.Length != 1)
+            if (children.Length == pc && Halt == HaltType.None)
                 return -1;
 
             return pc;

--- a/Slowsharp/Runner/Runner.Statement.cs
+++ b/Slowsharp/Runner/Runner.Statement.cs
@@ -48,7 +48,9 @@ namespace Slowsharp
             }
 
             Vars = prevVars;
-            if (children.Length == pc)
+            if (children.Length == pc) 
+                pc++;
+            else if (pc>children.Length)
                 return -1;
 
             return pc;

--- a/Slowsharp/Runner/Runner.Statement.cs
+++ b/Slowsharp/Runner/Runner.Statement.cs
@@ -17,9 +17,7 @@ namespace Slowsharp
 
             var children = node.ChildNodes().ToArray();
 
-            if (children.Length == pc)
-                return -1;
-
+        
             for (; pc < children.Length; pc++)
             {
                 var child = children[pc];
@@ -50,6 +48,8 @@ namespace Slowsharp
             }
 
             Vars = prevVars;
+            if (children.Length == pc)
+                return -1;
 
             return pc;
         }

--- a/Slowsharp/Runner/Runner.cs
+++ b/Slowsharp/Runner/Runner.cs
@@ -239,6 +239,7 @@ namespace Slowsharp
         }
         public void RunAsExecution(SyntaxNode node)
         {
+            Halt = HaltType.None;
             if (node is BlockSyntax)
                 RunBlock(node as BlockSyntax);
             else if (node is ArrowExpressionClauseSyntax)

--- a/Slowsharp/Runtime/SSEnumerator.cs
+++ b/Slowsharp/Runtime/SSEnumerator.cs
@@ -18,7 +18,7 @@ namespace Slowsharp
         private BlockSyntax block;
         private VarFrame vf;
         private Runner runner;
-
+        public SSInterpretMethodInfo Method;
         internal SSEnumerator(Runner runner, BlockSyntax node, VarFrame vf)
         {
             this.runner = runner;

--- a/Slowsharp/Runtime/SSEnumerator.cs
+++ b/Slowsharp/Runtime/SSEnumerator.cs
@@ -18,7 +18,11 @@ namespace Slowsharp
         private BlockSyntax block;
         private VarFrame vf;
         private Runner runner;
-        public SSInterpretMethodInfo Method;
+
+        public  SSInterpretMethodInfo Method;
+
+        public object Current => runner.Ret.Unwrap();
+
         internal SSEnumerator(Runner runner, BlockSyntax node, VarFrame vf)
         {
             this.runner = runner;
@@ -26,7 +30,6 @@ namespace Slowsharp
             this.vf = vf;
         }
 
-        public object Current => runner.Ret.Unwrap();
         public void Dispose()
         {
             // releases gc refs just in case


### PR DESCRIPTION
fixed bug

SSEnumerator returns 2,2,2,3,3 should return 2,3

```c#
IEnumerator Test(){
    yield return 2;
Debug.Log(4);
Debug.Log(4);
    yield return 3;
Debug.Log(5);
}
```