### PR TITLE
()=>{ } couldn't access Ctx.Method resulting null exceptions when try…

### DIFF
--- a/Slowsharp/Runner/Runner.Lambda.cs
+++ b/Slowsharp/Runner/Runner.Lambda.cs
@@ -120,10 +120,13 @@ namespace Slowsharp
 
                 if (ps.Count == 0)
                 {
+                    var ssInterpretMethodInfo = new SSInterpretMethodInfo(this, "__scripteval2", HybTypeCache.Void, null, new HybType[] { }, HybTypeCache.Void); 
                     body = new Action(() => {
+                        Ctx.PushMethod(ssInterpretMethodInfo);
                         RunBlock(node.Body as BlockSyntax);
                         if (Halt == HaltType.Return)
                             Halt = HaltType.None;
+                        Ctx.PopMethod();
                     });
                 }
                 else if (ps.Count == 1)


### PR DESCRIPTION
()=>{  
var a = SomeClass.instance.variable;  
} couldn't access Ctx.Method resulting null exceptions when trying to access static members

i don't know is this right way to fix it, if you could review it